### PR TITLE
Fixed 9 errors that occured when running 'rake spec' by changing let …

### DIFF
--- a/spec/bcoin/client/account_spec.rb
+++ b/spec/bcoin/client/account_spec.rb
@@ -5,8 +5,8 @@ module Bcoin
     RSpec.describe Account do
 
       # See comment for attr_reader :client in account.rb
-      let :client { Client.new }
-      let :wallet { Wallet.new(client, id: 'wallet123', token: 123) }
+      let(:client) { Client.new }
+      let(:wallet) { Wallet.new(client, id: 'wallet123', token: 123) }
       subject { Account.new(wallet, name: 'account123') }
 
       it "extends Bcoin::Client::Base" do

--- a/spec/bcoin/client/accounts_spec.rb
+++ b/spec/bcoin/client/accounts_spec.rb
@@ -5,8 +5,8 @@ module Bcoin
     RSpec.describe Accounts do
 
       # See comment for attr_reader :client in accounts.rb
-      let :client { Client.new }
-      let :wallet { Wallet.new(client, id: 'wallet123', token: 123) }
+      let(:client) { Client.new }
+      let(:wallet) { Wallet.new(client, id: 'wallet123', token: 123) }
       subject { Accounts.new wallet, [1,2,3] }
 
       it "extends Collection" do
@@ -37,7 +37,7 @@ module Bcoin
       end
 
       describe "#find" do
-        let :account { Account.new(wallet, {name: 'account123'}) }
+        let(:account) { Account.new(wallet, {name: 'account123'}) }
 
         it "instantiates a new Account with the name attribute" do
           expect(wallet).to receive(:get).and_return({name: 'account123'})

--- a/spec/bcoin/client/balance_spec.rb
+++ b/spec/bcoin/client/balance_spec.rb
@@ -5,8 +5,8 @@ module Bcoin
     RSpec.describe Balance do
 
       # See comment for attr_reader :client in account.rb
-      let :client { Client.new }
-      let :wallet { Wallet.new(client, id: 'wallet123', token: 123) }
+      let(:client) { Client.new }
+      let(:wallet) { Wallet.new(client, id: 'wallet123', token: 123) }
       subject { Balance.new(wallet, name: 'account123') }
 
       it "extends Bcoin::Client::Base" do

--- a/spec/bcoin/client/base_spec.rb
+++ b/spec/bcoin/client/base_spec.rb
@@ -4,7 +4,7 @@ module Bcoin
   class Client
     RSpec.describe Base do
 
-      let :client { Client.new }
+      let(:client) { Client.new }
       subject { Base.new(client, test: 123) }
 
       it "stores a reference to the current Bcoin::Client instance" do

--- a/spec/bcoin/client/collection_spec.rb
+++ b/spec/bcoin/client/collection_spec.rb
@@ -4,7 +4,7 @@ module Bcoin
   class Client
     RSpec.describe Collection do
 
-      let :client { Client.new }
+      let(:client) { Client.new }
       subject { Collection.new client, [1,2,3] }
 
       it "stores a reference to the current Bcoin::Client instance" do

--- a/spec/bcoin/client/http_methods_spec.rb
+++ b/spec/bcoin/client/http_methods_spec.rb
@@ -17,7 +17,7 @@ module Bcoin
 
     RSpec.describe 'Bcoin::Client::HttpMethods' do
 
-      let :client { Client.new }
+      let(:client) { Client.new }
       subject { TestClass.new(client) }
 
       it "stores a reference to the current Bcoin::Client instance" do

--- a/spec/bcoin/client/master_spec.rb
+++ b/spec/bcoin/client/master_spec.rb
@@ -5,9 +5,9 @@ module Bcoin
     RSpec.describe Master do
 
       # See comment for attr_reader :client in account.rb
-      let :master_json { load_mock! 'master.json' }
-      let :client { Client.new }
-      let :wallet { Wallet.new(client, id: 'wallet123', token: 123) }
+      let(:master_json) { load_mock! 'master.json' }
+      let(:client) { Client.new }
+      let(:wallet) { Wallet.new(client, id: 'wallet123', token: 123) }
       subject { Master.new(wallet, master_json) }
 
       it "extends Bcoin::Client::Base" do

--- a/spec/bcoin/client/wallet_spec.rb
+++ b/spec/bcoin/client/wallet_spec.rb
@@ -5,7 +5,7 @@ module Bcoin
 
     RSpec.describe Wallet do
 
-      let :client { Client.new }
+      let(:client) { Client.new }
       subject { Wallet.new(client, id: 'wallet123', token: 123, account: {name: 'default'}) }
 
       it "extends Bcoin::Client::Base" do

--- a/spec/bcoin/client/wallets_spec.rb
+++ b/spec/bcoin/client/wallets_spec.rb
@@ -5,7 +5,7 @@ module Bcoin
 
     RSpec.describe Wallets do
 
-      let :client { Client.new }
+      let(:client) { Client.new }
       subject { Wallets.new client, [1,2,3] }
 
       it "extends Collection" do
@@ -44,7 +44,7 @@ module Bcoin
       end
 
       describe "#find" do
-        let :wallet { Wallet.new(client, {id: 'wallet', token: 123}) }
+        let(:wallet) { Wallet.new(client, {id: 'wallet', token: 123}) }
         before do
           expect(wallet).to receive :refresh!
         end


### PR DESCRIPTION
…:wallet to let(:wallet), etc.

- The errors before the change can be seen here: https://pastebin.com/raw/1j8z936u
- After the syntax corrections included in this commit: https://pastebin.com/raw/ecDNKeRi